### PR TITLE
Added software license

### DIFF
--- a/doc/LICENSE
+++ b/doc/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015, Michigan State University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tools/BitMatrix.h
+++ b/tools/BitMatrix.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_BIT_MATRIX_H
 #define EMP_BIT_MATRIX_H
 

--- a/tools/BitSet.h
+++ b/tools/BitSet.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_BIT_SET_H
 #define EMP_BIT_SET_H
 

--- a/tools/BitVector.h
+++ b/tools/BitVector.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_BIT_VECTOR_H
 #define EMP_BIT_VECTOR_H
 

--- a/tools/DynamicStringSet.h
+++ b/tools/DynamicStringSet.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_DYNAMIC_STRING_SET_H
 #define EMP_DYNAMIC_STRING_SET_H
 

--- a/tools/FunctionSet.h
+++ b/tools/FunctionSet.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_FUNCTION_SET_H
 #define EMP_FUNCTION_SET_H
 

--- a/tools/Graph.h
+++ b/tools/Graph.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_GRAPH_H
 #define EMP_GRAPH_H
 

--- a/tools/ProbSchedule.h
+++ b/tools/ProbSchedule.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_PROB_SCHEDULE_H
 #define EMP_PROB_SCHEDULE_H
 

--- a/tools/Ptr.h
+++ b/tools/Ptr.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_PTR_H
 #define EMP_PTR_H
 

--- a/tools/Random.h
+++ b/tools/Random.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_RANDOM_H
 #define EMP_RANDOM_H
 

--- a/tools/SolveState.h
+++ b/tools/SolveState.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_SOLVE_STATE_H
 #define EMP_SOLVE_STATE_H
 

--- a/tools/Trait.h
+++ b/tools/Trait.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_TRAIT_H
 #define EMP_TRAIT_H
 

--- a/tools/alert.h
+++ b/tools/alert.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_ALERT_H
 #define EMP_ALERT_H
 

--- a/tools/assert.h
+++ b/tools/assert.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_ASSERT_H
 #define EMP_ASSERT_H
 

--- a/tools/bitset_utils.h
+++ b/tools/bitset_utils.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_BITSET_UTILS_H
 #define EMP_BITSET_UTILS_H
 

--- a/tools/class.h
+++ b/tools/class.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_CLASS_H
 #define EMP_CLASS_H
 

--- a/tools/command_line.h
+++ b/tools/command_line.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_COMMAND_LINE_H
 #define EMP_COMMAND_LINE_H
 

--- a/tools/const.h
+++ b/tools/const.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_CONST_H
 #define EMP_CONST_H
 

--- a/tools/const_utils.h
+++ b/tools/const_utils.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_CONST_UTILS_H
 #define EMP_CONST_UTILS_H
 

--- a/tools/errors.h
+++ b/tools/errors.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_ERRORS_H
 #define EMP_ERRORS_H
 

--- a/tools/fixed.h
+++ b/tools/fixed.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_FIXED_H
 #define EMP_FIXED_H
 

--- a/tools/functions.h
+++ b/tools/functions.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_FUNCTIONS_H
 #define EMP_FUNCTIONS_H
 

--- a/tools/graph_utils.h
+++ b/tools/graph_utils.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_GRAPH_UTILS_H
 #define EMP_GRAPH_UTILS_H
 

--- a/tools/grid.h
+++ b/tools/grid.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_GRID_H
 #define EMP_GRID_H
 

--- a/tools/macro_math.h
+++ b/tools/macro_math.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_MACRO_MATH_H
 #define EMP_MACRO_MATH_H
 

--- a/tools/macros.h
+++ b/tools/macros.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_MACROS_H
 #define EMP_MACROS_H
 

--- a/tools/mem_track.h
+++ b/tools/mem_track.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_MEM_TRACK
 #define EMP_MEM_TRACK
 

--- a/tools/random_utils.h
+++ b/tools/random_utils.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_RANDOM_UTILS_H
 #define EMP_RANDOM_UTILS_H
 

--- a/tools/reflection.h
+++ b/tools/reflection.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_REFLECTION_H
 #define EMP_REFLECTION_H
 

--- a/tools/sequence_utils.h
+++ b/tools/sequence_utils.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_SEQUENCE_UTILS_H
 #define EMP_SEQUENCE_UTILS_H
 

--- a/tools/serialize.h
+++ b/tools/serialize.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_SERIALIZE_H
 #define EMP_SERIALIZE_H
 

--- a/tools/serialize_macros.h
+++ b/tools/serialize_macros.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_SERIALIZE_MACROS_H
 #define EMP_SERIALIZE_MACROS_H
 

--- a/tools/string_utils.h
+++ b/tools/string_utils.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_STRING_UTILS_H
 #define EMP_STRING_UTILS_H
 

--- a/tools/tuple_struct.h
+++ b/tools/tuple_struct.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_TUPLE_STRUCT_H
 #define EMP_TUPLE_STRUCT_H
 

--- a/tools/unit_tests.h
+++ b/tools/unit_tests.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_UNIT_TESTS_H
 #define EMP_UNIT_TESTS_H
 

--- a/tools/vector.h
+++ b/tools/vector.h
@@ -1,3 +1,7 @@
+// This file is part of Empirical, https://github.com/mercere99/Empirical/, and is 
+// Copyright (C) Michigan State University, 2015. It is licensed 
+// under the MIT Software license; see doc/LICENSE
+
 #ifndef EMP_VECTOR_H
 #define EMP_VECTOR_H
 


### PR DESCRIPTION
@mercere99 I've added an MIT license. I'll incorporate it into the docs once those are a thing.

I figure we'll want to add some kind of header to most of the project files:

```
This file is part of Empirical [link to github page], and is 
Copyright (C) Michigan State University, 2015. It is licensed 
under the MIT Software license; see doc/LICENSE
```

Thoughts/opinions?